### PR TITLE
add organization id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Output Name | Environment Variable | Description
 `projectToken` | `METAL_PROJECT_TOKEN` | a new Equinix Metal Project API Token bound to this project
 `projectSSHPrivateKey` | `METAL_SSH_PRIVATE_KEY_FILE`  | a new SSH Private Key that can be used to authenticate to devices in this project
 `projectSSHPublicKey` | `METAL_SSH_PUBLIC_KEY_FILE`  | a new SSH Public Key that can be used to authenticate to devices in this project
+`organizationID` | `METAL_ORGANIZATION_ID` | ID of the Organization responsible for the project.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Output Name | Environment Variable | Description
 `projectID` | `METAL_PROJECT_ID` | a new Equinix Metal Project ID
 `projectName` | `METAL_PROJECT_NAME` | the generated (or supplied) name of the Equinix Metal Project
 `projectToken` | `METAL_PROJECT_TOKEN` | a new Equinix Metal Project API Token bound to this project
-`projectSSHPrivateKey` | `METAL_SSH_PRIVATE_KEY_FILE`  | a new SSH Private Key that can be used to authenticate to devices in this project
-`projectSSHPublicKey` | `METAL_SSH_PUBLIC_KEY_FILE`  | a new SSH Public Key that can be used to authenticate to devices in this project
+`projectSSHPrivateKeyFile` | `METAL_SSH_PRIVATE_KEY_FILE`  | a new SSH Private Key that can be used to authenticate to devices in this project
+`projectSSHPublicKeyFile` | `METAL_SSH_PUBLIC_KEY_FILE`  | a new SSH Public Key that can be used to authenticate to devices in this project
 `organizationID` | `METAL_ORGANIZATION_ID` | ID of the Organization responsible for the project.

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 		"projectToken":             p.APIToken,
 		"projectSSHPrivateKeyFile": sshPrivateFile,
 		"projectSSHPublicKeyFile":  sshPublicFile,
+		"organizationID":           p.Project.Organization.ID,
 	} {
 		fmt.Printf("::set-output name=%s::%s\n", k, url.QueryEscape(v))
 	}
@@ -81,6 +82,7 @@ func main() {
 		"METAL_PROJECT_TOKEN":        p.APIToken,
 		"METAL_SSH_PRIVATE_KEY_FILE": sshPrivateFile,
 		"METAL_SSH_PUBLIC_KEY_FILE":  sshPublicFile,
+		"METAL_ORGANIZATION_ID":      p.Project.Organization.ID,
 	} {
 		fmt.Fprintf(envFile, "%s<<EOS\n%s\nEOS\n", k, v)
 	}


### PR DESCRIPTION
Fixes #5 

I'm not sure if organization id is returned by default when creating projects.

packngo does not expose a parameter to see the include options on this create request.
