### PR TITLE
feat: rename the project and dependencies for the equinix-labs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Experimental Github Action for creating [Equinix Metal](https://metal.equinix.co
 
 > :bulb: See also:
 >
-> - [equinix-metal-sweeper](https://github.com/displague/metal-sweeper-action) action
-> - [equinix-metal-examples](https://github.com/displague/metal-actions-example) examples
+> - [equinix-metal-sweeper](https://github.com/equinix-labs/metal-sweeper-action) action
+> - [equinix-metal-examples](https://github.com/equinix-labs/metal-actions-example) examples
 
 Given a Equinix Metal User API Token, a new Project will be created, preconfigured with an SSH Key and API Key which can be used in subsequent actions.
 
-Clean up the project with the [Equinix Metal Sweeper Action](https://github.com/displague/metal-sweeper-action).
+Clean up the project with the [Equinix Metal Sweeper Action](https://github.com/equinix-labs/metal-sweeper-action).
 
-See the [Equinix Metal Actions Example](https://github.com/displague/metal-actions-example) for usage examples.
+See the [Equinix Metal Actions Example](https://github.com/equinix-labs/metal-actions-example) for usage examples.
 
 ## Input
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/displague/metal-project-action
+module github.com/equinix-labs/metal-project-action
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 
-	action "github.com/displague/metal-project-action/internal"
+	action "github.com/equinix-labs/metal-project-action/internal"
 )
 
 func main() {


### PR DESCRIPTION
Moves the project docs and dependencies to equinix-labs from displague, along with
* https://github.com/equinix-labs/metal-actions-example/pull/3
* https://github.com/equinix-labs/metal-sweeper-action/pull/9
