### PR TITLE
fix: get project organization details without using additionalproperties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/equinix-labs/metal-project-action
 go 1.14
 
 require (
-	github.com/equinix-labs/metal-go v0.8.0
+	github.com/equinix-labs/metal-go v0.9.1-0.20230615170029-6f8b25231753
 	golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/equinix-labs/metal-go v0.8.0 h1:s5mDkQREvsor4KGe9+6Wzu/Rx0N2KZWhWVRfI+R2S74=
-github.com/equinix-labs/metal-go v0.8.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.9.0 h1:eEkX7jRY06RblH3C3yHnT0lmRbasYrD68iNwl8esLGg=
+github.com/equinix-labs/metal-go v0.9.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.9.1-0.20230615170029-6f8b25231753 h1:M070R6NsKR3xBimc0yzRPQ8yY6Z/LeTHXte8lARPT1Y=
+github.com/equinix-labs/metal-go v0.9.1-0.20230615170029-6f8b25231753/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/internal/action.go
+++ b/internal/action.go
@@ -65,8 +65,10 @@ func (a *action) CreateProject() (*Project, error) {
 		createOpts.OrganizationId = &a.organizationID
 	}
 
+	includes := []string{"organization.id"}
+
 	log.Println("Creating Project")
-	project, _, err := a.client.ProjectsApi.CreateProject(context.Background()).ProjectCreateFromRootInput(createOpts).Execute()
+	project, _, err := a.client.ProjectsApi.CreateProject(context.Background()).ProjectCreateFromRootInput(createOpts).Include(includes).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -66,17 +66,13 @@ func main() {
 		fmt.Printf("::add-mask::%s\n", url.QueryEscape(v))
 	}
 
-	// TODO remove this when organization is mentioned in the project schema
-	organization := p.Project.AdditionalProperties["organization"].(map[string]interface{})
-	organizationId := fmt.Sprint(organization["id"])
-
 	for k, v := range map[string]string{
 		"projectID":                  p.Project.GetId(),
 		"projectName":                p.Project.GetName(),
 		"projectToken":               p.APIToken,
 		"projectSSHPrivateKeyBase64": sshPrivateBase64,
 		"projectSSHPublicKey":        sshPublicKey,
-		"organizationID":             organizationId,
+		"organizationID":             p.Project.Organization.GetId(),
 	} {
 		fmt.Fprintf(outputFile, "%s=%s\n", k, url.QueryEscape(v))
 	}
@@ -87,7 +83,7 @@ func main() {
 		"METAL_PROJECT_TOKEN":          p.APIToken,
 		"METAL_SSH_PRIVATE_KEY_BASE64": sshPrivateBase64,
 		"METAL_SSH_PUBLIC_KEY":         sshPublicKey,
-		"METAL_ORGANIZATION_ID":        organizationId,
+		"METAL_ORGANIZATION_ID":        p.Project.Organization.GetId(),
 	} {
 		fmt.Fprintf(envFile, "%s<<EOS\n%s\nEOS\n", k, v)
 	}


### PR DESCRIPTION
This upgrades `metal-go` so that we can use named properties to get a project's organization data rather than using `additionalProperties`.  This also updates the create project request to tell the API to send back the organization ID.  This has been broken since before the metal-go switch, and it seems more useful to add the missing include parameter than to remove the always-been-empty organization ID output.