### PR TITLE
Provide full path to version variable to `go build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM golang as build
 WORKDIR /code
 COPY . .
 # Need to manually bump this before each release
-ENV ACTION_VERSION=0.12.0
+ENV ACTION_VERSION=0.12.1
 ENV CGO_ENABLED=0
-RUN go build -ldflags "-X 'action.version=${ACTION_VERSION}'"
+RUN go build -ldflags "-X 'github.com/equinix-labs/metal-project-action/internal.version=${ACTION_VERSION}'"
 
 FROM alpine
 COPY --from=build /code/metal-project-action /bin/metal-project-action


### PR DESCRIPTION
In order to modify a variable in a package other than `main`, you have to provide the full module name, not just the package name. This was recently fixed in the terraform provider but I forgot that it was a thing.