### PR TITLE
feat: clean up environment variable lookups / writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ See the [Equinix Metal Actions Example](https://github.com/equinix-labs/metal-ac
 
 ## Input
 
-| With             | Environment variable | Description                                                                                                                      |
-| ---------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `userToken`      | `METAL_AUTH_TOKEN`   | (required) A Equinix Metal User API Token                                                                                        |
-| `projectName`    | -                    | Name for the project, API key, and SSH Key. A generated name will be used if not supplied.                                       |
-| `organizationID` | -                    | Organization ID that the Project will be created under. If not supplied, the default organization for the API User will be used. |
+| With             | Description                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `userToken`      | (required) A Equinix Metal User API Token                                                                 |
+| `projectName`    | Name for the project, API key, and SSH Key. A generated name will be used if not supplied.                |
+| `organizationID` | Organization ID that the Project will be created under. If not supplied, the default organization for the API User will be used. |
 
 ## Output
 
-| Output Name                  | Environment Variable         | Description                                                                                        |
-| ---------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `projectID`                  | `METAL_PROJECT_ID`           | a new Equinix Metal Project ID                                                                     |
-| `projectName`                | `METAL_PROJECT_NAME`         | the generated (or supplied) name of the Equinix Metal Project                                      |
-| `projectToken`               | `METAL_PROJECT_TOKEN`        | a new Equinix Metal Project API Token bound to this project                                        |
-| `projectSSHPrivateKeyBase64` | `METAL_SSH_PRIVATE_KEY_FILE` | a new SSH Private Key (base64 encoded) that can be used to authenticate to devices in this project |
-| `projectSSHPublicKey`        | `METAL_SSH_PUBLIC_KEY_FILE`  | a new SSH Public Key that can be used to authenticate to devices in this project                   |
-| `organizationID`             | `METAL_ORGANIZATION_ID`      | ID of the Organization responsible for the project.                                                |
+| Output Name                  | Description                                                         |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `projectID`                  | a new Equinix Metal Project ID                                      |
+| `projectName`                | the generated (or supplied) name of the Equinix Metal Project                         
+| `projectToken`               | a new Equinix Metal Project API Token bound to this project                         
+| `projectSSHPrivateKeyBase64` | a new SSH Private Key (base64 encoded) that can be used to authenticate to devices in this project |
+| `projectSSHPublicKey`        | a new SSH Public Key that can be used to authenticate to devices in this project                   |
+| `organizationID`             | ID of the Organization responsible for the project.                                                |

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ See the [Equinix Metal Actions Example](https://github.com/equinix-labs/metal-ac
 
 ## Input
 
-| With             | Description                                                                                               |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `userToken`      | (required) A Equinix Metal User API Token                                                                 |
-| `projectName`    | Name for the project, API key, and SSH Key. A generated name will be used if not supplied.                |
+| With             | Description                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `userToken`      | (required) A Equinix Metal User API Token                                                                                        |
+| `projectName`    | Name for the project, API key, and SSH Key. A generated name will be used if not supplied.                                       |
 | `organizationID` | Organization ID that the Project will be created under. If not supplied, the default organization for the API User will be used. |
 
 ## Output
 
-| Output Name                  | Description                                                         |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `projectID`                  | a new Equinix Metal Project ID                                      |
-| `projectName`                | the generated (or supplied) name of the Equinix Metal Project                         
-| `projectToken`               | a new Equinix Metal Project API Token bound to this project                         
+| Output Name                  | Description                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `projectID`                  | a new Equinix Metal Project ID                                                                     |
+| `projectName`                | the generated (or supplied) name of the Equinix Metal Project                                      |
+| `projectToken`               | a new Equinix Metal Project API Token bound to this project                                        |
 | `projectSSHPrivateKeyBase64` | a new SSH Private Key (base64 encoded) that can be used to authenticate to devices in this project |
 | `projectSSHPublicKey`        | a new SSH Public Key that can be used to authenticate to devices in this project                   |
 | `organizationID`             | ID of the Organization responsible for the project.                                                |

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: 'Equinix Metal Organization ID for the Project. The default organization for the user will be used by the API if this is not provided.'
     required: false
   userToken:
-    description: 'The user API key to use when creating the project.  Required if `env.METAL_AUTH_TOKEN` is not specified'
-    required: false
+    description: 'The user API key to use when creating the project.'
+    required: true
 outputs:
   projectID:
     description: 'The UUID of the created project'

--- a/main.go
+++ b/main.go
@@ -11,20 +11,17 @@ import (
 )
 
 func main() {
-	projectName := os.Getenv("INPUTS_PROJECTNAME")
+	projectName := os.Getenv("INPUT_PROJECTNAME")
 	if projectName == "" {
 		projectName = action.GenProjectName(os.Getenv("GITHUB_SHA"))
 	}
 
-	apiToken := os.Getenv("INPUTS_USERTOKEN")
+	apiToken := os.Getenv("INPUT_USERTOKEN")
 	if apiToken == "" {
-		apiToken = os.Getenv("METAL_AUTH_TOKEN")
-		if apiToken == "" {
-			log.Fatal("Either `with.userToken` or `env.METAL_AUTH_TOKEN` must be supplied")
-		}
-
+		log.Fatal("Either `with.userToken` or `env.METAL_AUTH_TOKEN` must be supplied")
 	}
-	a, err := action.NewAction(apiToken, os.Getenv("INPUTS_ORGANIZATIONID"), projectName)
+
+	a, err := action.NewAction(apiToken, os.Getenv("INPUT_ORGANIZATIONID"), projectName)
 	if err != nil {
 		log.Fatal("Could not create client action", err)
 	}
@@ -75,16 +72,5 @@ func main() {
 		"organizationID":             p.Project.Organization.GetId(),
 	} {
 		fmt.Fprintf(outputFile, "%s=%s\n", k, url.QueryEscape(v))
-	}
-
-	for k, v := range map[string]string{
-		"METAL_PROJECT_ID":             p.Project.GetId(),
-		"METAL_PROJECT_NAME":           p.Project.GetName(),
-		"METAL_PROJECT_TOKEN":          p.APIToken,
-		"METAL_SSH_PRIVATE_KEY_BASE64": sshPrivateBase64,
-		"METAL_SSH_PUBLIC_KEY":         sshPublicKey,
-		"METAL_ORGANIZATION_ID":        p.Project.Organization.GetId(),
-	} {
-		fmt.Fprintf(envFile, "%s<<EOS\n%s\nEOS\n", k, v)
 	}
 }


### PR DESCRIPTION
Our actions should take GitHub Actions inputs (no custom env vars) and produce GitHub Actions outputs (no custom env vars in the env file that get automatically exposed to subsequent steps).

The only environment variables our action should look at are the ones passed in by GitHub Actions (`INPUT_*`, `GITHUB_*`, maybe others)