### PR TITLE
feat: pick non-default icon and color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,3 +28,6 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+branding:
+  icon: 'folder-plus'
+  color: 'green'


### PR DESCRIPTION
This updates the action config to specify a non-default icon and color.  Currently this action shows up in the marketplace with a red color and a "play" icon.  This changes the color to green to match our other actions, and changes the icon to a folder with a plus in it, since that seems to most closely match the intent of the action (to create a new place to store things).